### PR TITLE
Add more robust error handling for downloads

### DIFF
--- a/src/js/sagas/downloads.js
+++ b/src/js/sagas/downloads.js
@@ -14,6 +14,7 @@ const downloadFile = async (fileUrl, fileName) => chrome.downloads.download({url
 
 const getFilePathFromId = (state, fileId) => {
   let file = state.files.filesById[fileId]
+  console.log(file)
   let courseName = state.classes.classesById[file.courseId].title
   let parentName = state.pages.pagesById[getPageIdFromComponents(file.courseId, file.parentContentId)].title
   // BB sometimes has course names with leading and trailing spaces, chrome doesn't like that
@@ -69,12 +70,17 @@ export function * downloadSelectedFiles () {
   try {
     let selectedFilesById = yield select(getSelectedFiles)
     for (const fileId of _.keys(selectedFilesById)) {
-      let fileUrl = yield select(getFileUrlFromId, fileId)
-      let filePath = yield select(getFilePathFromId, fileId)
-      console.log(filePath)
-      yield call(downloadFile, fileUrl, filePath)
-      yield put.resolve(unselectFileAction(fileId))
-      yield put.resolve(markFileAsDownloadedAction(fileId))
+      try {
+        let fileUrl = yield select(getFileUrlFromId, fileId)
+        let filePath = yield select(getFilePathFromId, fileId)
+        console.log(filePath)
+        yield call(downloadFile, fileUrl, filePath)
+        yield put.resolve(unselectFileAction(fileId))
+        yield put.resolve(markFileAsDownloadedAction(fileId))
+        
+      } catch (e) {
+        console.log("Failed to download file:", e)
+      }
     }
   } catch (e) {
     console.log(e)

--- a/src/js/sagas/parser.js
+++ b/src/js/sagas/parser.js
@@ -51,7 +51,11 @@ export function * parseAllClasses (action) {
     let unparsedPages = yield select(getUnparsedPages)
     while (_.some(unparsedPages)) {
       let visitedPages = yield call(batchProcessClasses, unparsedPages, tabIds)
-      yield put(batchActions(_.map(visitedPages, (page) => visitPage(page))))
+      try {
+        yield put(batchActions(_.map(visitedPages, (page) => visitPage(page))))
+      } catch (e) {
+        console.log("Failed parsing pages:", e)
+      }
       unparsedPages = yield select(getUnparsedPages)
     }
     console.log('Finished Parse')


### PR DESCRIPTION
Downloads on the course page blow up the downloader,  Wrap things in trycatch to avoid inevitable errors from stopping downloads.